### PR TITLE
Bump money-tree to >= 0.11.0 (fix macOS 15 libcrypto abort)

### DIFF
--- a/cryptocoin_payable.gemspec
+++ b/cryptocoin_payable.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activerecord-import', '~> 1.5'
   spec.add_dependency 'cash-addr', '~> 0.2'
   spec.add_dependency 'eth', '0.5.11'
-  spec.add_dependency 'money-tree', '0.10.0'
+  spec.add_dependency 'money-tree', '>= 0.11.0'
   spec.add_dependency 'state_machines-activerecord', '~> 0.5'
   spec.add_dependency 'rqrcode', '~> 2.2'
   spec.add_dependency 'image_processing', '~> 1.12'

--- a/lib/cryptocoin_payable/version.rb
+++ b/lib/cryptocoin_payable/version.rb
@@ -1,3 +1,3 @@
 module CryptocoinPayable
-  VERSION = '2.0.0'.freeze
+  VERSION = '2.1.0'.freeze
 end


### PR DESCRIPTION
## Summary
- Bump `money-tree` dependency from `= 0.10.0` to `>= 0.11.0`
- Release `cryptocoin_payable` `2.1.0`

## Why
`money-tree 0.10.0` contains this line in `lib/openssl_extensions.rb`:

```ruby
ffi_lib ['libssl.so.1.0.0', 'libssl.so.10', 'libssl1.0.0', 'ssl']
```

On macOS host Ruby (not devcontainer/Linux), the bare `'ssl'` falls through to `/usr/lib/libssl.dylib` — Apple's unversioned stub. After Homebrew's `openssl@3` is already loaded in the process via Ruby's stdlib `openssl`, this triggers Apple's `"loading libcrypto in an unsafe way"` abort on macOS 15+ (SIGIOT). Rails server / Puma can't boot.

`money-tree 0.11.0` (Nov 2022) specifically [removed this unsafe FFI path](https://rubygems.org/gems/money-tree/versions/0.11.0) — per release notes: *"service release to remove unsafe ffi and monkey patches to openssl to mainly fix linking issues for macOS users"*.

See also: [GemHQ/money-tree#38](https://github.com/GemHQ/money-tree/issues/38).

## Test plan
- [ ] `bundle install` in a downstream app resolves `money-tree 0.11.x`
- [ ] Rails boots on macOS 15 host Ruby (no libcrypto abort)
- [ ] Existing `cryptocoin_payable` functionality (BTC address generation via money-tree) still works
